### PR TITLE
Correction d'une erreur de niveau dans le Leader

### DIFF
--- a/siri/index.md
+++ b/siri/index.md
@@ -544,10 +544,7 @@ par les attributs suivants
             </td>
         </tr>
         <tr>
-            <td >
-                <p><br></p>
-            </td>
-            <td >
+            <td colspan="2" >
                 <p>Description</p>
             </td>
             <td colspan="2" >


### PR DESCRIPTION
La **Description** était incluse dans le **choice** par erreur (erreur dans le document source)